### PR TITLE
Partially fix build - Update target dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,11 +132,11 @@ set(MINISERVO_SRCS
     src/libcef_dll/transfer_util.cpp
    )
 
-link_directories(${GTK3_LIBRARY_DIRS} ../servo/ports/cef/target/debug)
+link_directories(${GTK3_LIBRARY_DIRS} ../servo/target/debug)
 
-file(GLOB cef_libs "../servo/ports/cef/target/debug/libembedding*")
+file(GLOB cef_libs "../servo/target/debug/libembedding*")
 get_filename_component(cef_file ${cef_libs} NAME_WE)
-string(SUBSTRING ${cef_file}, 3, 26, cef_hash)
+string(SUBSTRING ${cef_file}, 3, 9, cef_hash)
 
 add_executable(miniservo ${MINISERVO_SRCS})
 


### PR DESCRIPTION
miniservo fails when building against the latest servo.

One issue is that the target dir where `libembedding.so` changed. This is fixed by this pull request.

Another issue NOT ADDRESSED HERE is new libraries that servo uses which causes missing references when linking against `libembedding.so`
1. Undefined reference to `gluCheckExtension`: Can be fixed by linking against `GLU`.
2. Undefined reference to `CreateARGBImageEncoder`: This is a skia function, but it's undefined in `libskia.a` that servo builds.
